### PR TITLE
remove IOKit

### DIFF
--- a/loader/palera1nLoader/External/Bridge.h
+++ b/loader/palera1nLoader/External/Bridge.h
@@ -1,5 +1,4 @@
 #include <spawn.h>
-#include <IOKit/IOKitlib.h>
 
 @import Foundation;
 


### PR DESCRIPTION
At least from what I can see, there is no place where the loader uses anything from it(?). I tried compiling without it, and everything seems fine and doesn't look to have any effect on the compiled binary.

Removing this makes development experience much better, as before you couldn't compile this on systems without this IOKit header, now with the changes it's possible.