### PR TITLE
feat: add proper functionality to the newly provided url scheme

### DIFF
--- a/palera1nLoader.xcodeproj/project.pbxproj
+++ b/palera1nLoader.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/palera1nLoader/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = palera1nTV;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
@@ -547,6 +548,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/palera1nLoader/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = palera1nTV;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;

--- a/palera1nLoader/AppDelegate.swift
+++ b/palera1nLoader/AppDelegate.swift
@@ -23,5 +23,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if let host = url.host {
+            if host == "restart-pineboard" {
+                spawn(command: "/cores/binpack/bin/launchctl", args: ["kickstart", "-k", "system/com.apple.backboardd"])
+            }
+        }
+        return true
+    }
 }
 

--- a/palera1nLoader/AppDelegate.swift
+++ b/palera1nLoader/AppDelegate.swift
@@ -24,11 +24,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if let host = url.host {
-            if host == "restart-pineboard" {
-                spawn(command: "/cores/binpack/bin/launchctl", args: ["kickstart", "-k", "system/com.apple.backboardd"])
-            }
-        }
+		if let host = url.host {
+
+			if host == "restart-pineboard" || host == "restart-springboard" {
+				spawn(command: "/cores/binpack/bin/launchctl", args: ["kickstart", "-k", "system/com.apple.backboardd"])
+			}
+
+			if host == "userspace-reboot" {
+				spawn(command: "/cores/binpack/bin/launchctl", args: ["reboot", "userspace"])
+			}
+
+			if host == "uicache" {
+				spawn(command: "/cores/binpack/usr/bin/uicache", args: ["-a"])
+			}
+
+			if let config = url.absoluteString.range(of: "/config/") {
+				let fullPath = String(url.absoluteString[config.upperBound...])
+				
+				if OptionsViewController().isValidURL(fullPath) {
+					Preferences.installPath = fullPath
+				} else {
+					log(type: .fatal, msg: "The URL must be a valid json URL!")
+				}
+			}
+
+
+		}
         return true
     }
 }


### PR DESCRIPTION
This makes it easier for other apps to restart PineBoard.

It can be used from another app with:
```
UIApplication.shared.open(URL(string: "loader://restart-pineboard")!)
```

Or with the Simulator:
```
xcrun simctl openurl booted loader://restart-pineboard
```