### PR TITLE
Add URL scheme functionlity

### DIFF
--- a/Loader/AppDelegate.swift
+++ b/Loader/AppDelegate.swift
@@ -22,6 +22,41 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
 	}
 	
+	func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+		handle(url: url)
+	}
+	
+	func handle(url: URL) -> Bool {
+		if let host = url.host {
+			if host == "restart-pineboard" || host == "restart-springboard" {
+				LREnvironment.shared.respring()
+			}
+			
+			if host == "userspace-reboot" {
+				LREnvironment.shared.rebootUserspace()
+			}
+			
+			if host == "uicache" {
+				LREnvironment.shared.uicacheAll()
+			}
+			
+			if let config = url.absoluteString.range(of: "/config/") {
+				let fullPath = String(url.absoluteString[config.upperBound...])
+				
+				if let configURL = URL(string: fullPath),
+				   let scheme = configURL.scheme?.lowercased(),
+				   (scheme == "http" || scheme == "https"),
+				   configURL.pathExtension.lowercased() == "json" {
+					UserDefaults.standard.set(fullPath, forKey: "defaultInstallPath")
+				} else {
+					print("The URL must be a valid json URL!")
+				}
+			}
+		}
+
+		return true
+	}
+
 	func applicationWillTerminate(_ application: UIApplication) {
 		self._cleanTmpDir()
 	}
@@ -50,4 +85,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		}
 	}
 }
-

--- a/Loader/Resources/Info.plist
+++ b/Loader/Resources/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>in.palera.loader</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>loader</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Loader/SceneDelegate.swift
+++ b/Loader/SceneDelegate.swift
@@ -24,6 +24,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		window.rootViewController = controller
 		window.makeKeyAndVisible()
 		self.window = window
+		
+		guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+		for context in connectionOptions.urlContexts {
+			_ = appDelegate.handle(url: context.url)
+		}
+	}
+
+	func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+		guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+		for context in URLContexts {
+			_ = appDelegate.handle(url: context.url)
+		}
 	}
 }
 


### PR DESCRIPTION
This reimplements the changes from #66 which didn't seem to be migrated from the `2.0` branch.

This is how it was tested:
1. Create a unique bundle identifier
2. Run `make package PLATFORM=appletvos PACKAGE_NAME=palera1nLoaderTV`
3. Copy `palera1nLoaderTV.app` to `/Applications/palera1nLoaderTV1.app`
4. Run `uicache -p palera1nLoaderTV1.app || ucache -a`
5. Call `UIApplication.shared.open(URL(string: "loader://restart-pineboard")!)`
